### PR TITLE
Add `handleAllRequests` property

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -129,3 +129,13 @@ NSURLProtocol.registerClass(MockingBird)
 ~~~
 
 But beware, if you're using an `NSURLSession` with this set, it will not work for the sessions, this one works only for the old version without `NSURLSession`
+
+#### Handle all requests
+
+By default, if a request does not match an entry in the current Mocking-Bundle, the request is passed through to the network as usual.  If you would like any request that does not match to fail, set the `handleAllRequests` property to true.
+
+~~~swift
+MockingBird.handleAllRequests = true
+~~~
+
+When this property is set to true, requests that do not match the current Mocking-Bundle will fail with an HTTP error status of 501.

--- a/src/mockingbird.swift
+++ b/src/mockingbird.swift
@@ -81,7 +81,7 @@ public class MockingBird: NSURLProtocol {
     // If this is true, we'll claim to answer all URL requests.
     // If this is false, URLs that don't match will be passed on
     //      through to normal handlers.
-    static var handleAllRequests: Bool = false
+    public static var handleAllRequests: Bool = false
 
     public enum Error: ErrorType {
         case MockBundleNotFound

--- a/tests/mockingbirdTests.swift
+++ b/tests/mockingbirdTests.swift
@@ -71,6 +71,19 @@ class mockingbirdTests: XCTestCase {
         self.waitForExpectationsWithTimeout(2.0, handler: nil)
     }
     
+    func testHandleAll() {
+        let expectation = self.expectationWithDescription("testHandleAll")
+
+        MockingBird.handleAllRequests = true
+        
+        self.alamofire.request(.GET, "http://httpbin.org/html").response { (request, response, data, error) in
+            XCTAssertTrue(response!.statusCode == 501)
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectationsWithTimeout(2.0, handler: nil)
+    }
+
     func testMock() {
         let expectation = self.expectationWithDescription("testMock")
         


### PR DESCRIPTION
If the property is false (the default), the library works as before.
If the property is true, the library responsds to all network requests and fails with error code 501 for those that don’t match an entry in the Mocking-Bundle.
