### PR TITLE
Preparations for iOS13 deployment target:

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-source 'https://github.com/CocoaPods/Specs'
+source 'https://cdn.cocoapods.org/'
 
 use_frameworks!
 
@@ -8,32 +8,32 @@ def shared_pods
 end
 
 target 'mockingbird_ios' do
-	platform :ios, '8.4'
+	platform :ios, '13.0'
 	shared_pods
 end
 
 target 'mockingbird_ios_host' do
-	platform :ios, '8.4'
+	platform :ios, '13.0'
 	shared_pods
 end
 
 target 'mockingbird_ios tests' do
-	platform :ios, '8.4'
+	platform :ios, '13.0'
 	shared_pods
 end
 
 target 'mockingbird_osx' do
-	platform :osx, '10.10'
+	platform :osx, '11.0'
 	shared_pods
 end
 
 target 'mockingbird_osx_host' do
-	platform :osx, '10.10'
+	platform :osx, '11.0'
 	shared_pods
 end
 
 target 'mockingbird_osx tests' do
-	platform :osx, '10.10'
+	platform :osx, '11.0'
 	shared_pods
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ DEPENDENCIES:
   - DEjson (from `https://github.com/anfema/DEjson`, branch `master`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - Alamofire
 
 EXTERNAL SOURCES:
@@ -22,8 +22,8 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
-  DEjson: 0289c921f19778a6dc4d1d4d7f0ffd4b2c4cafad
+  DEjson: 4344603627c3628b09b6f84d805f5d506f26b97e
 
-PODFILE CHECKSUM: f6a3e9d3dfe8fd515c81ba5af28a1b308f377365
+PODFILE CHECKSUM: 54c3b7e379b3138d36372125708fc8dd830e26dd
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.11.2

--- a/anfema-mockingbird.podspec
+++ b/anfema-mockingbird.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "anfema-mockingbird"
-  s.version      = "4.0.0"
+  s.version      = "5.0.0"
   s.summary      = "HTTP-Response mocking for iOS and OS X."
   s.description  = <<-DESC
                    HTTP-Response mocking for iOS and OS X
@@ -17,16 +17,16 @@ Pod::Spec.new do |s|
   s.author             = { "Johannes Schriewer" => "j.schriewer@anfe.ma" }
   s.social_media_url   = "http://twitter.com/dunkelstern"
 
-  s.ios.deployment_target = "8.4"
-  s.osx.deployment_target = "10.10"
+  s.ios.deployment_target = "13.0"
+  s.osx.deployment_target = "11.0"
 
-  s.source       = { :git => "https://github.com/anfema/Mockingbird.git", :tag => "4.0.0" }
+  s.source       = { :git => "https://github.com/anfema/Mockingbird.git", :tag => "5.0.0" }
   s.source_files  = "src/*.swift"
   
   s.framework  = "Alamofire", "DEjson"
 
   s.dependency "Alamofire", "~> 4.2"
-  s.dependency "DEjson", "~> 4.0"
+  s.dependency "DEjson", "~> 5.0"
 
   s.swift_version = '5.0'
 end

--- a/mockingbird.xcodeproj/project.pbxproj
+++ b/mockingbird.xcodeproj/project.pbxproj
@@ -466,7 +466,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1310;
 				ORGANIZATIONNAME = "Johannes Schriewer";
 				TargetAttributes = {
 					8F0DB0721C0F48E200193E8C = {
@@ -889,6 +889,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -914,8 +915,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -949,6 +950,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -968,8 +970,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -1068,7 +1070,8 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = ios/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.anfema.mockingbird;
 				PRODUCT_NAME = mockingbird;
@@ -1092,7 +1095,8 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = ios/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.anfema.mockingbird;
 				PRODUCT_NAME = mockingbird;
@@ -1114,7 +1118,7 @@
 					"$(PROJECT_DIR)/build/Debug-iphoneos",
 				);
 				INFOPLIST_FILE = tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.anfema.mockingbirdTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1134,7 +1138,7 @@
 					"$(PROJECT_DIR)/build/Debug-iphoneos",
 				);
 				INFOPLIST_FILE = tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.anfema.mockingbirdTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1149,7 +1153,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 775224E3198E7E37175AA548 /* Pods-mockingbird_ios_host.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1158,7 +1161,7 @@
 					"$(PROJECT_DIR)/build/Debug/Pods-mockingbird_osx",
 				);
 				INFOPLIST_FILE = ios/host/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.anfema.mockingbird-ios-host";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1172,7 +1175,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7C4D7C06BE71646CEF55805F /* Pods-mockingbird_ios_host.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1181,7 +1183,7 @@
 					"$(PROJECT_DIR)/build/Debug/Pods-mockingbird_osx",
 				);
 				INFOPLIST_FILE = ios/host/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.anfema.mockingbird-ios-host";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1197,10 +1199,11 @@
 			baseConfigurationReference = ED9F3E3751CC1B08F2A862E4 /* Pods-mockingbird_osx_host.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = osx/host/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.anfema.mockingbird-osx-host";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -1212,10 +1215,11 @@
 			baseConfigurationReference = 31408F512C232076610C13D9 /* Pods-mockingbird_osx_host.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = osx/host/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.anfema.mockingbird-osx-host";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
- Updated project settings
- Increased minimum deployment target to iOS 13.0 and macos 11.0
- Updated podspec
- Updated podfile